### PR TITLE
Use `Layer.isActive()` instead of `Layer.isOn()`

### DIFF
--- a/src/Kaleidoscope/PrefixLayer.cpp
+++ b/src/Kaleidoscope/PrefixLayer.cpp
@@ -40,7 +40,7 @@ EventHandlerResult PrefixLayer::onKeyswitchEvent(Key &mapped_key, byte row, byte
     for (uint8_t i = 0;; i++) {
       uint16_t layer = pgm_read_word(&(dict[i].layer));
       if (layer == 0xFFFF) break;
-      if (Layer.isOn(layer)) {
+      if (Layer.isActive(layer)) {
         for (uint8_t j = 0;; j++) {
           Key k;
           k.raw = pgm_read_word(&(dict[i].prefix_seq[j].raw));


### PR DESCRIPTION
https://github.com/keyboardio/Kaleidoscope/blob/aecc29a31341cd21f5d90133b5bcf9237eb981a5/UPGRADING.md#more-clarity-in-layer-method-names

```
/home/ilianaw/git/Model01-Firmware/Kaleidoscope-PrefixLayer/src/Kaleidoscope/PrefixLayer.cpp: In member function 'kaleidoscope::EventHandlerResult kaleidoscope::plugin::PrefixLayer::onKeyswitchEvent(kaleidoscope::Key&, byte, byte, uint8_t)':
/home/ilianaw/git/Model01-Firmware/Kaleidoscope-PrefixLayer/src/Kaleidoscope/PrefixLayer.cpp:43:27: warning: 'static boolean kaleidoscope::Layer_::isOn(uint8_t)' is deprecated (declared at /home/ilianaw/git/Model01-Firmware/hardware/keyboardio/avr/libraries/Kaleidoscope/src/kaleidoscope/layers.h:102):
------------------------------------------------------------------------
Please use `Layer.isActive()` instead of `Layer.isOn().`
------------------------------------------------------------------------
 [-Wdeprecated-declarations]
       if (Layer.isOn(layer)) {
                           ^
```