### PR TITLE
Removed spurious termination of event handling

### DIFF
--- a/src/Kaleidoscope/PrefixLayer.cpp
+++ b/src/Kaleidoscope/PrefixLayer.cpp
@@ -57,7 +57,6 @@ EventHandlerResult PrefixLayer::onKeyswitchEvent(Key &mapped_key, byte row, byte
                                WAS_PRESSED | INJECTED);
         }
         hid::sendKeyboardReport();
-        return EventHandlerResult::EVENT_CONSUMED;
       }
     }
   }


### PR DESCRIPTION
This should fix a bug where a key on a prefix layer with a modifier flag loses its modifier behaviour because of an interaction with Kaleidoscope-HIDAdaptor-KeyboardioHID. It's a bit complex to explain here, but basically the return line removed here was incorrect, because it aborted the keypress event. The keycode would still get added to subsequent reports, but it would be added as a held key, not a newly-pressed key, and because it never got added as newly-pressed, its modifiers never got added to the bitmask that allows mod flags to be added to the report.

Fixes #2